### PR TITLE
Download CSS properties JSON and deploy to GitHub pages

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,26 @@
+name: Download CSS properties and deploy site
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Re-deploy monthly just in case all-properties.en.json changes...
+    - cron: '0 19 1 * *'
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  setup-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Download CSS properties JSON
+        run: |
+          wget https://www.w3.org/Style/CSS/all-properties.en.json -O ./assets/all-properties.en.json
+
+      - name: Deploy to GitHub pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: .

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,6 +1,6 @@
 const googles_css_popularity_url = "https://chromestatus.com/data/csspopularity";
 const serenitys_css_properties_url = "https://raw.githubusercontent.com/SerenityOS/serenity/master/Userland/Libraries/LibWeb/CSS/Properties.json";
-const w3c_css_properties_url = `https://api.allorigins.win/raw?url=${encodeURIComponent('https://www.w3.org/Style/CSS/all-properties.en.json')}`;
+const w3c_css_properties_url = "assets/all-properties.en.json";
 
 list_element = document.getElementById("list");
 stat_element = document.getElementById("stat");


### PR DESCRIPTION
This removes the use of https://api.allorigins.win/ which regularly goes down and takes (on my fast network) over 30 seconds to load the a 22kb JSON file! Instead, the site is now deployed to GitHub pages once a month. As part of the deploy steps the all-properties.en.json is fetched and saved to the assets folder (which avoids any CORS issues, and is nice and fast).

Once this PR is merged just go into Settings > Pages, then using "Deploy from a branch" select the (newly created by the workflow) gh-pages branch, which will be automatically updated once a month. 

I've tested this in my fork and it all seems to work, and now the page loads pretty much instantly: https://macdue.github.io/Serenity-CSS-properties/